### PR TITLE
ReadMTXE bug  and metadata issues fixed

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
   - family-names: Kozin
     given-names: "V. K."
 title: "QDistRnd: Calculate the distance of a q-ary quantum stabilizer code"
-version: v0.9.3
-date-released: 2024-02-06
+version: v0.9.5
+date-released: 2024-11-20
 repository-code: "https://github.com/QEC-pages/QDistRnd"
 url: "https://QEC-pages.github.io/QDistRnd/"
 keywords:

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,8 +16,8 @@ SetPackageInfo(
         rec( 
              PackageName := "QDistRnd",             
              Subtitle := "Calculate the distance of a q-ary quantum stabilizer code",
-             Version := "0.9.4",
-             Date := "23/02/2024",  
+             Version := "0.9.5",
+             Date := "20/11/2024",  
              License := "GPL-2.0-or-later",
              PackageWWWHome := "https://QEC-pages.github.io/QDistRnd", 
              SourceRepository :=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `GAP` package `QDistRnd`
 The `GAP` package for calculating the distance of a $q$-ary quantum
-stabilizer code.
+stabilizer code
 
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.04120/status.svg)](https://doi.org/10.21105/joss.04120)
 

--- a/lib/qdistrnd.g
+++ b/lib/qdistrnd.g
@@ -484,7 +484,7 @@ BindGlobal("ReadMTXE",
                          # iCommentStart, iComment - range of line numbers for comment section
                          
                          infile := InputTextFile(StrPath);                          
-                         input := ReadAll();;                        # read the file in
+                         input := ReadAll(infile);;                        # read the file in
                          CloseStream(infile);                         
                          data := SplitString(input, "\n");;         # separate into lines
                          line := SplitString(data[1], " ");;         # separate into records

--- a/lib/qdistrnd.g
+++ b/lib/qdistrnd.g
@@ -483,9 +483,9 @@ BindGlobal("ReadMTXE",
                          # i - dummy for "for" loop
                          # iCommentStart, iComment - range of line numbers for comment section
                          
-                         infile := InputTextFile(StrPath);                          
+                         infile := InputTextFile(StrPath);
                          input := ReadAll(infile);;                        # read the file in
-                         CloseStream(infile);                         
+                         CloseStream(infile);
                          data := SplitString(input, "\n");;         # separate into lines
                          line := SplitString(data[1], " ");;         # separate into records
                          

--- a/lib/qdistrnd.g
+++ b/lib/qdistrnd.g
@@ -465,7 +465,7 @@ BindGlobal("QDR_ProcEntry",
 #DeclareGlobalFunction("ReadMTXE");
 BindGlobal("ReadMTXE",
                      function(StrPath, opt... ) # supported option: "field"
-                         local input, data, fmt, line, pair, F, rowsG, colsG, G, G1, i, 
+                         local input, data, fmt, line, pair, F, rowsG, colsG, G, G1, i, infile,
                                iCommentStart,iComment;
                          # local variables:
                          # input - file converted to a string
@@ -483,7 +483,9 @@ BindGlobal("ReadMTXE",
                          # i - dummy for "for" loop
                          # iCommentStart, iComment - range of line numbers for comment section
                          
-                         input := ReadAll(InputTextFile(StrPath));; # read the file in
+                         infile := InputTextFile(StrPath);                          
+                         input := ReadAll();;                        # read the file in
+                         CloseStream(infile);                         
                          data := SplitString(input, "\n");;         # separate into lines
                          line := SplitString(data[1], " ");;         # separate into records
                          


### PR DESCRIPTION
1. ReadMTXE() now correctly closes the input text stream (closes #44)
2. Fixed a README.md header line (removed "." at the end of the line) (along with a prior change, this closes #43)
3. Updated version number and release date in PackageInfo.g